### PR TITLE
Add manual trigger for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'VERSION'
+  workflow_dispatch:
 
 env:
   rgbds_version: v1.0.1


### PR DESCRIPTION
## Summary

Add `workflow_dispatch` trigger to allow manually running the release workflow from the GitHub Actions UI.

## Changes

Added `workflow_dispatch:` to the workflow triggers.

## Usage

1. Go to **Actions** tab
2. Select **Release** workflow
3. Click **Run workflow** button
4. Select `main` branch and click **Run workflow**

The workflow will still check if the release already exists and skip if so.