### PR TITLE
Fix Lipx command syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Create IPS patch
         if: steps.check_release.outputs.exists == 'false'
         run: |
-          lipx -c pokecrystal11.orig.gbc pokecrystal11vn.gbc pokecrystal11vn.ips
+          lipx create pokecrystal11.orig.gbc pokecrystal11vn.gbc pokecrystal11vn.ips
           echo "IPS patch created"
           ls -la pokecrystal11vn.ips
 
@@ -108,7 +108,7 @@ jobs:
         run: |
           # Apply patch to original and compare with Vietnamese ROM
           cp pokecrystal11.orig.gbc patched.gbc
-          lipx -a patched.gbc pokecrystal11vn.ips
+          lipx apply pokecrystal11vn.ips patched.gbc
           
           # Compare checksums
           PATCHED_SHA=$(sha1sum patched.gbc | cut -d' ' -f1)


### PR DESCRIPTION
## Summary

Fix the Lipx command syntax in the release workflow.

## Problem

Used incorrect flag-based syntax:
- `lipx -c original modified output.ips`
- `lipx -a file patch.ips`

## Solution

Use correct word-based syntax:
- `lipx create original modified output.ips`
- `lipx apply patch.ips file`