### PR TITLE
Fix Lipx apply output filename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,11 +107,11 @@ jobs:
         if: steps.check_release.outputs.exists == 'false'
         run: |
           # Apply patch to original and compare with Vietnamese ROM
-          cp pokecrystal11.orig.gbc patched.gbc
-          lipx apply pokecrystal11vn.ips patched.gbc
+          # lipx apply creates output file with _patched suffix
+          lipx apply pokecrystal11vn.ips pokecrystal11.orig.gbc
           
-          # Compare checksums
-          PATCHED_SHA=$(sha1sum patched.gbc | cut -d' ' -f1)
+          # Compare checksums (output is pokecrystal11.orig_patched.gbc)
+          PATCHED_SHA=$(sha1sum pokecrystal11.orig_patched.gbc | cut -d' ' -f1)
           EXPECTED_SHA=$(sha1sum pokecrystal11vn.gbc | cut -d' ' -f1)
           
           if [ "$PATCHED_SHA" = "$EXPECTED_SHA" ]; then


### PR DESCRIPTION
## Summary

Fix the verification step to use the correct output filename from Lipx.

## Problem

`lipx apply` doesn't modify files in-place. It creates a new file with `_patched` suffix.

For example:
```
lipx apply patch.ips file.gbc
```
Creates `file_patched.gbc`, not modifying `file.gbc`.

## Solution

- Remove the unnecessary `cp` command
- Check the correct output file: `pokecrystal11.orig_patched.gbc`