### PR TITLE
Add write permissions for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
       - 'VERSION'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 env:
   rgbds_version: v1.0.1
   # Commit hash of the original pret/pokecrystal that our Vietnamese version is based on


### PR DESCRIPTION
## Summary

Add `permissions: contents: write` to the release workflow.

## Problem

```
HTTP 403: Resource not accessible by integration
```

The workflow doesn't have permission to create releases.

## Solution

Add explicit permissions block:

```yaml
permissions:
  contents: write
```

This allows `gh release create` to work.