### PR TITLE
docs: Revise FONT_MAPPING.md for clarity and updates

### DIFF
--- a/FONT_MAPPING.md
+++ b/FONT_MAPPING.md
@@ -2,9 +2,9 @@
 
 ## Complete Character Map (font.png → charmap.asm)
 
-This document shows the **NEW trading-compatible layout** that maximizes compatibility with English Pokemon Crystal for link cable trading/battling.
+This document shows the **trading-compatible layout** that maximizes compatibility with English Pokemon Crystal for link cable trading/battling.
 
-### Layout Grid (NEW - Trading Compatible)
+### Layout Grid (Trading Compatible)
 
 | Row | $x0 | $x1  | $x2  | $x3 | $x4 | $x5 | $x6 | $x7 | $x8 | $x9 | $xA | $xB | $xC | $xD | $xE | $xF |
 |-----|-----|------|------|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|
@@ -17,57 +17,36 @@ This document shows the **NEW trading-compatible layout** that maximizes compati
 | $Ex | '   | <PK> | <MN> | -   | ←   | đ   | ?   | !   | .   | &   | é   | →   | ▷   | ▶   | ▼   | ♂   |
 | $Fx | ¥   | x    | .    | /   | ,   | ♀   | 0   | 1   | 2   | 3   | 4   | 5   | 6   | 7   | 8   | 9   |
 
-### Trading Compatibility Strategy
+By sharing the same glyphs for $80-$9f, we can achieve IDENTICAL to English version
 
-**Problem:** Vietnamese and English versions have different font layouts. When trading Pokemon with nicknames:
-- English sends `$80-$99` for lowercase a-z
-- Vietnamese needs to decode these to Vietnamese a-z characters
-
-**Solution:** This NEW layout puts a-z and punctuation at **identical positions** as English Crystal:
-
-#### Range $80-$9F: IDENTICAL to English Crystal
 | Code Range | Characters | Status |
 |------------|------------|--------|
-| $80-$8F | a-p | ✅ **MATCHES ENGLISH** |
-| $90-$99 | q-z | ✅ **MATCHES ENGLISH** |
+| $80-$8F | A-P | ✅ **MATCHES ENGLISH** |
+| $90-$99 | Q-Z | ✅ **MATCHES ENGLISH** |
 | $9A-$9F | ( ) : ; [ ] | ✅ **MATCHES ENGLISH** |
+| $A9-$DF | accented Vietnamese chars | **NO MATCH** |
+| $E0-$EF | , PK MN, symbols | ✅ **MATCHES ENGLISH** |
+| $F0-$FF | ¥ x . / , ♀, 0-9 | ✅ **MATCHES ENGLISH** |
 
-#### Range $A0-$DF: Vietnamese Accented Characters
+### NOTES:
+
+- the `$E4` and `$E5` are empty glyphs in English, so Vietnamese allocation of `←` and `đ` will ensure 100% compatability.
+- `←` moved to `$E4` from `$DF` will not have any impact on compatability because this symbol is disallowed to be used for name boxes, player and Pokémons.
+- There is no `ỵ` - unused in actual Vietnamese text, freed space for reorganization
+
+### Accented Vietnamese characters organisation
+
 Organized by **vowel families** for logical grouping:
 - **$A0-$AF**: a-family (á à ả ã ạ) + ă-family (ă ắ ằ ẳ ẵ ặ) + â-family (â ấ ầ ẩ ẫ)
 - **$B0-$BF**: â-family cont. (ậ) + e-family (è ẻ ẽ ẹ) + ê-family (ê ế ề ể ễ ệ) + i-family (í ì ỉ ĩ ị)
 - **$C0-$CF**: u-family (ú ù ủ ũ ụ) + ư-family (ư ứ ừ ử ữ ự) + o-family (ó ò ỏ õ ọ)
 - **$D0-$DF**: ô-family (ô ố ồ ổ ỗ ộ) + ơ-family (ơ ớ ờ ở ỡ ợ) + y-family (ý ỳ ỷ ỹ)
 
-#### Range $E0-$EF: Punctuation + Special Characters
-- `đ` moved to $E5 (freed $9D for semicolon `;`)
-- `←` moved to $E4
-- `é` at $EA
-
-### Key Changes from OLD Layout
-
-**Removed from $9x:**
-- `đ` moved from $9D → $E5 (freed $9D for `;`)
-
-**New positions for base vowels:**
-- `ă` moved from $E4 → $A5
-- `â` moved from $E5 → $AB
-- `ê` moved from $A5 → $B5
-- `ư` moved from $AF → $C5
-- `ô` moved from $BF → $D0
-- `ơ` moved from $CF → $D6
-
-**Removed character:**
-- `ỵ` (ỹ with dot below) - unused in actual Vietnamese text, freed space for reorganization
-
-### Usage
-
-Character codes now directly map to font positions:
-- Text contains character code (e.g., `$D7` for "ớ")
-- Game renders tile ID `$D7` which loads from VRAM position `$D7`
-- VRAM was loaded from font.png position `$D7 - $80 = $57` (row 5, col 7)
+The contiguous organisation will simplify the logic of mapping accented characters to equivalent non-accented characters.
 
 ### Uppercase Mapping
+
+There is NO concept of uppercase and lowercase in Vietnamese font system, a trade-off to squeeze all accented chars in same font sprites
 
 All uppercase Vietnamese letters map to their lowercase equivalents (updated positions):
 - `Ă` → `$A5` (lowercase `ă`)
@@ -81,6 +60,14 @@ All uppercase Vietnamese letters map to their lowercase equivalents (updated pos
 
 All other toned vowels (Á, À, Ả, Ắ, Ấ, Ế, Ố, etc.) map to their lowercase codes.
 
+### Trading Compatibility Strategy
+
+**Problem:** Vietnamese and English versions have different font layouts. When trading Pokemon with nicknames:
+- English sends `$A0-$B9` for lowercase a-z
+- Vietnamese will wrongly render `$A0-$B9` as á-ị
+
+**Solution:** To devise a translation layer to map them to correct glyphs on Vietnamese side. 
+
 ### Next Steps: Translation Layer
 
 To enable trading with English Crystal, implement translation functions:
@@ -89,12 +76,12 @@ To enable trading with English Crystal, implement translation functions:
    - Already compatible! No translation needed for basic a-z.
 
 2. **TranslateVietnameseToEnglish**: Convert Vietnamese accented characters to base letters
-   - á à ả ã ạ ă ắ ằ ẳ ẵ ặ â ấ ầ ẩ ẫ ậ → a
-   - é è ẻ ẽ ẹ ê ế ề ể ễ ệ → e
-   - í ì ỉ ĩ ị → i
-   - ó ò ỏ õ ọ ô ố ồ ổ ỗ ộ ơ ớ ờ ở ỡ ợ → o
-   - ú ù ủ ũ ụ ư ứ ừ ử ữ ự → u
-   - ý ỳ ỷ ỹ → y
-   - đ → d
+   - á à ả ã ạ ă ắ ằ ẳ ẵ ặ â ấ ầ ẩ ẫ ậ → a (`$80`)
+   - é è ẻ ẽ ẹ ê ế ề ể ễ ệ → e (`$84`)
+   - í ì ỉ ĩ ị → i (`$88`)
+   - ó ò ỏ õ ọ ô ố ồ ổ ỗ ộ ơ ớ ờ ở ỡ ợ → o (`$8E`)
+   - ú ù ủ ũ ụ ư ứ ừ ử ữ ự → u (`$94`)
+   - ý ỳ ỷ ỹ → y (`$98`)
+   - đ → d (`$83`)
 
 3. **Hook into link cable code** in `engine/link/` to automatically translate names during trading/battling.


### PR DESCRIPTION
Updated font mapping document to clarify trading compatibility layout and character organization for Vietnamese and English versions of Pokemon Crystal.