### PR TITLE
Update ROM title to PKMN_PHA_LE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ $(foreach obj, $(pokecrystal11_vc_obj), $(eval $(call DEP,$(obj),$(obj:11_vc.o=.
 endif
 
 
-RGBFIXFLAGS += -Cjv -t PM_CRYSTAL -k 01 -l 0x33 -m MBC3+TIMER+RAM+BATTERY -r 3 -p 0
+RGBFIXFLAGS += -Cjv -t PKMN_PHA_LE -k 01 -l 0x33 -m MBC3+TIMER+RAM+BATTERY -r 3 -p 0
 pokecrystal.gbc:         RGBFIXFLAGS += -i BYTE -n 0
 pokecrystal11.gbc:       RGBFIXFLAGS += -i BYTE -n 1
 pokecrystal_au.gbc:      RGBFIXFLAGS += -i BYTU -n 0


### PR DESCRIPTION
## Summary

- Change ROM title from `PM_CRYSTAL` to `PKMN_PHA_LE` (Pokémon Pha Lê - Vietnamese for "Crystal")
- ROM title is limited to 11 characters when game ID is specified
- This makes the ROM identifiable as the Vietnamese version in emulators and ROM managers

## Technical Details

- ROM header title at offset 0x134-0x13E
- Uses rgbfix `-t PKMN_PHA_LE` flag in Makefile