### PR TITLE
Translate island and tower location names to Vietnamese

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -703,11 +703,11 @@ This document contains all English-Vietnamese translation terms used in the Viet
 | SLOWPOKE WELL | GIẾNG<BSP>SLOWPOKE |
 | RADIO TOWER | THÁP<BSP>RADIO |
 | NATIONAL PARK | VƯỜN<BSP>QUỐC GIA |
-| TIN TOWER | THÁP<BSP>THIẾC |
+| TIN TOWER | THÁP<BSP>CHUÔNG |
 | BURNED TOWER | THÁP<BSP>CHÁY |
 | LIGHTHOUSE | HẢI ĐĂNG |
 | BATTLE TOWER | THÁP<BSP>CHIẾN ĐẤU |
-| WHIRL ISLANDS | QUẦN ĐẢO<BSP>WHIRL |
+| WHIRL ISLANDS | ĐẢO<BSP>XOÁY NƯỚC |
 | MT.MORTAR | NÚI<BSP>MORTAR |
 | DRAGON'S DEN | HANG<BSP>RỒNG |
 | ICE PATH | LỐI ĐI<BSP>BĂNG ĐÁ |
@@ -738,7 +738,7 @@ This document contains all English-Vietnamese translation terms used in the Viet
 | LAV RADIO TOWER | THÁP RADIO<BSP>LAV |
 | SILPH CO. | SILPH CO. |
 | SAFARI ZONE | KHU SAFARI |
-| SEAFOAM ISLANDS | ĐẢO<BSP>SEAFOAM |
+| SEAFOAM ISLANDS | ĐẢO<BSP>BỌT BIỂN |
 | POKEMON MANSION | DINH THỰ<BSP>#MON |
 | CERULEAN CAVE | ĐỘNG<BSP>CERULEAN |
 | DIGLETT'S CAVE | ĐỘNG<BSP>DIGLETT |

--- a/data/maps/landmarks.asm
+++ b/data/maps/landmarks.asm
@@ -128,9 +128,9 @@ SlowpokeWellName:    db "GIẾNG<BSP>SLOWPOKE@"
 RadioTowerName:      db "THÁP<BSP>RADIO@"
 PowerPlantName:      db "NHÀ MÁY<BSP>ĐIỆN@"
 NationalParkName:    db "VƯỜN<BSP>QUỐC GIA@"
-TinTowerName:        db "THÁP<BSP>THIẾC@"
+TinTowerName:        db "THÁP<BSP>CHUÔNG@"
 LighthouseName:      db "HẢI ĐĂNG@"
-WhirlIslandsName:    db "QUẦN ĐẢO<BSP>WHIRL@"
+WhirlIslandsName:    db "ĐẢO<BSP>XOÁY NƯỚC@"
 MtMortarName:        db "NÚI<BSP>MORTAR@"
 DragonsDenName:      db "HANG<BSP>RỒNG@"
 IcePathName:         db "LỐI ĐI<BSP>BĂNG ĐÁ@"
@@ -152,7 +152,7 @@ RockTunnelName:      db "ĐƯỜNG HẦM<BSP>ĐÁ@"
 LavRadioTowerName:   db "THÁP RADIO<BSP>LAV@"
 SilphCoName:         db "SILPH CO.@" ; unreferenced
 SafariZoneName:      db "KHU SAFARI@" ; unreferenced
-SeafoamIslandsName:  db "ĐẢO<BSP>SEAFOAM@"
+SeafoamIslandsName:  db "ĐẢO<BSP>BỌT BIỂN@"
 PokemonMansionName:  db "DINH THỰ<BSP>#MON@" ; unreferenced
 CeruleanCaveName:    db "ĐỘNG<BSP>CERULEAN@" ; unreferenced
 Route1Name:          db "ĐƯỜNG<BSP>1@"

--- a/maps/CinnabarIsland.asm
+++ b/maps/CinnabarIsland.asm
@@ -116,7 +116,7 @@ CinnabarIslandGymSignText:
 
 	para "GYM CINNABAR đã"
 	line "chuyển đến ĐẢO"
-	cont "SEAFOAM."
+	cont "BỌT BIỂN."
 
 	para "BLAINE"
 	done

--- a/maps/CinnabarPokecenter1F.asm
+++ b/maps/CinnabarPokecenter1F.asm
@@ -23,7 +23,7 @@ CinnabarPokecenter1FCooltrainerFText:
 
 	para "sống một mình ở"
 	line "hang động ĐẢO"
-	cont "SEAFOAM…"
+	cont "BỌT BIỂN…"
 	done
 
 CinnabarPokecenter1FFisherText:

--- a/maps/Route19.asm
+++ b/maps/Route19.asm
@@ -156,7 +156,7 @@ SwimmerfDawnAfterBattleText:
 	text "Bơi nhanh giữa"
 	line "FUCHSIA và"
 
-	para "ĐẢO SEAFOAM…"
+	para "ĐẢO BỌT BIỂN…"
 	line "mà…"
 
 	para "Chà, bạn trai tôi"
@@ -220,13 +220,13 @@ Route19SignText:
 	text "ĐƯỜNG 19"
 
 	para "TP.FUCHSIA -"
-	line "ĐẢO SEAFOAM"
+	line "ĐẢO BỌT BIỂN"
 	done
 
 CarefulSwimmingSignText:
 	text "Hãy cẩn thận nếu"
 	line "bạn đang bơi đến"
-	cont "ĐẢO SEAFOAM."
+	cont "ĐẢO BỌT BIỂN."
 
 	para "C.SÁT FUCHSIA"
 	done

--- a/maps/Route41.asm
+++ b/maps/Route41.asm
@@ -214,8 +214,8 @@ SwimmermKirkAfterBattleText:
 
 SwimmermMathewSeenText:
 	text "Bạn đang tìm kiếm"
-	line "bí mật của QUẦN"
-	cont "ĐẢO WHIRL?"
+	line "bí mật của ĐẢO"
+	cont "XOÁY NƯỚC?"
 	done
 
 SwimmermMathewBeatenText:
@@ -224,8 +224,8 @@ SwimmermMathewBeatenText:
 	done
 
 SwimmermMathewAfterBattleText:
-	text "Bí mật về QUẦN"
-	line "ĐẢO WHIRL…"
+	text "Bí mật về ĐẢO"
+	line "XOÁY NƯỚC…"
 
 	para "Bên trong tối mù"
 	line "mịt!"
@@ -233,8 +233,8 @@ SwimmermMathewAfterBattleText:
 
 SwimmerfKayleeSeenText:
 	text "Tôi đang trên"
-	line "đường đến QUẦN"
-	cont "ĐẢO WHIRL."
+	line "đường đến ĐẢO"
+	cont "XOÁY NƯỚC."
 
 	para "Tôi đi khám phá"
 	line "với bạn bè."


### PR DESCRIPTION
## Summary

- Translates **WHIRL ISLANDS**: `QUẦN ĐẢO WHIRL` → `ĐẢO XOÁY NƯỚC`
- Translates **SEAFOAM ISLANDS**: `ĐẢO SEAFOAM` → `ĐẢO BỌT BIỂN`
- Translates **TIN TOWER**: `THÁP THIẾC` → `THÁP CHUÔNG`

## Files Changed

| File | Changes |
|------|---------|
| `data/maps/landmarks.asm` | Updated landmark definitions |
| `maps/Route41.asm` | 3 dialogue references to Whirl Islands |
| `maps/Route19.asm` | 3 dialogue references to Seafoam Islands |
| `maps/CinnabarIsland.asm` | 1 dialogue reference to Seafoam |
| `maps/CinnabarPokecenter1F.asm` | 1 dialogue reference to Seafoam |
| `GLOSSARY.md` | Updated translation entries |

## Translation Notes

- **ĐẢO XOÁY NƯỚC** (Whirlpool Island) - Describes the whirlpool mechanics
- **ĐẢO BỌT BIỂN** (Sea Foam Island) - Literal translation of "Seafoam"
- **THÁP CHUÔNG** (Bell Tower) - More meaningful than literal "THÁP THIẾC" (Tin Tower); the tower is famous for its bells

## Build Status

✅ ROM compiles successfully with `make -j4`