### PR TITLE
Use #GEAR macro instead of POKEGEAR in text

### DIFF
--- a/maps/CherrygroveCity.asm
+++ b/maps/CherrygroveCity.asm
@@ -407,12 +407,12 @@ GuideGentGiftText:
 	done
 
 GotMapCardText:
-	text "POKEGEAR của"
+	text "#GEAR của"
 	line "<PLAYER> có BẢN ĐỒ"
 	done
 
 GuideGentPokegearText:
-	text "POKEGEAR sẽ hữu"
+	text "#GEAR sẽ hữu"
 	line "ích hơn khi bạn"
 	cont "thêm THẺ vào."
 
@@ -488,7 +488,7 @@ CherrygroveTeacherText_NoMapCard:
 
 	para "Ông ấy sẽ cài BẢN"
 	line "ĐỒ JOHTO vào"
-	cont "POKEGEAR của bạn."
+	cont "#GEAR của bạn."
 	done
 
 CherrygroveTeacherText_HaveMapCard:


### PR DESCRIPTION
## Summary

Replace `POKEGEAR` with `#GEAR` in CherrygroveCity dialog text to use the proper macro that expands to `POKéGEAR` with the special é character.

## Changes

- `maps/CherrygroveCity.asm`: 3 text string replacements

## Before/After

| Before | After |
|--------|-------|
| `POKEGEAR của` | `POKéGEAR của` |
| `POKEGEAR sẽ hữu` | `POKéGEAR sẽ hữu` |
| `POKEGEAR của bạn.` | `POKéGEAR của bạn.` |