### PR TITLE
Improve escape battle text phrasing

### DIFF
--- a/data/text/battle.asm
+++ b/data/text/battle.asm
@@ -265,7 +265,8 @@ BattleText_TheresNoEscapeFromTrainerBattle:
 	prompt
 
 BattleText_GotAwaySafely:
-	text "Thoát an toàn!"
+	text "Chạy thoát an"
+	line "toàn!"
 	prompt
 
 BattleText_UserFledUsingAStringBuffer1:


### PR DESCRIPTION
## Summary

Improves the battle escape message from "Thoát an toàn!" to "Chạy thoát an toàn!"

## Change

| Before | After |
|--------|-------|
| Thoát an toàn! | Chạy thoát an toàn! |

## Why?

"Chạy thoát" (ran away/escaped by running) is more natural and descriptive Vietnamese phrasing than just "Thoát" (escaped). It better conveys the action of fleeing from battle.